### PR TITLE
Allow fs.write to hidden folders in android

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports = function(options){
             resolve(fs.root);
           } else {
             folders = folders.split('/').filter(function(folder) {
-              return folder && folder.length > 0 && folder[0] !== '.';
+              return folder && folder.length > 0 && folder !== '.' && folder !== '..';
             });
             __createDir(fs.root,folders,resolve,reject);
           }


### PR DESCRIPTION
Example:

fs.write(".hidden/test.txt","A test!");

Used to fail:
                        E  TypeError: Wrong type for parameter "path" of DirectoryEntry.getDirectory: Expected String, but got Undefined.
                        E      at TypeError (<anonymous>)
                        E      at Object.checkArgs (file:///android_asset/www/cordova.js:416:15)
                        E      at DirectoryEntry.getDirectory (file:///android_asset/www/plugins/org.apache.cordova.file/www/Director
                           yEntry.js:69:15)
                        E      at __createDir (file:///android_asset/www/lib/CordovaPromiseFS.js:54:17)
                        E      at file:///android_asset/www/lib/CordovaPromiseFS.js:178:14
                        E      at processQueue (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:20962:27)
                        E      at file:///android_asset/www/lib/ionic/js/ionic.bundle.js:20978:27
                        E      at Scope.$eval (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:22178:28)
                        E      at Scope.$digest (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:21994:31)
                        E      at Scope.$apply (file:///android_asset/www/lib/ionic/js/ionic.bundle.js:22282:24) at file:///android_asset/www/lib/ionic/js/ionic.bundle.js:19387

But with this commit it should work.