### PR TITLE
Assume URLs are well-formed instead of trying to encode them for the user

### DIFF
--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -444,7 +444,6 @@ var CordovaPromiseFS =
 	      onprogress = transferOptions;
 	      transferOptions = {};
 	    }
-	    serverUrl = encodeURI(serverUrl);
 	    if(isCordova && localPath.indexOf('://') < 0) localPath = toInternalURLSync(localPath);
 
 	    transferOptions = transferOptions || {};

--- a/index.js
+++ b/index.js
@@ -397,7 +397,6 @@ module.exports = function(options){
       onprogress = transferOptions;
       transferOptions = {};
     }
-    serverUrl = encodeURI(serverUrl);
     if(isCordova && localPath.indexOf('://') < 0) localPath = toInternalURLSync(localPath);
 
     transferOptions = transferOptions || {};


### PR DESCRIPTION
Hi,

I had a use case where a URL contained encoded parameters in its query string. Trying to upload to an endpoint with `fs.upload` would corrupt the parameters by re-encoding them, although the URL was already perfectly fine.

This pull request removes the call to `encodeURI`, assuming users will be able to take care of the proper encoding of their URLs themselves.

Cheers,
Eevert