### PR TITLE
Strip trailing slash on dir path

### DIFF
--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -213,6 +213,12 @@ var CordovaPromiseFS =
 
 	  /* list contents of a directory */
 	  function list(path,mode) {
+
+	    // Strip trailing slash to prevent fs.root.getDirectory in function dir from returning with a file not found error on Windows 
+	    if (path.substr(-1) === '/') {
+	      path = path.substr(0, path.length - 1);
+	    }
+
 	    mode = mode || '';
 	    var recursive = mode.indexOf('r') > -1;
 	    var getAsEntries = mode.indexOf('e') > -1;

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -199,6 +199,12 @@ var CordovaPromiseFS =
 	  /* get directory entry */
 	  function dir(path,options){
 	    path = normalize(path);
+
+	    // Strip trailing slash to prevent fs.root.getDirectory in function dir from returning with a file not found error on Windows 
+	    if (path.substr(-1) === '/') {
+	      path = path.substr(0, path.length - 1);
+	    }
+
 	    options = options || {};
 	    return new Promise(function(resolve,reject){
 	      return fs.then(function(fs){
@@ -213,12 +219,6 @@ var CordovaPromiseFS =
 
 	  /* list contents of a directory */
 	  function list(path,mode) {
-
-	    // Strip trailing slash to prevent fs.root.getDirectory in function dir from returning with a file not found error on Windows 
-	    if (path.substr(-1) === '/') {
-	      path = path.substr(0, path.length - 1);
-	    }
-
 	    mode = mode || '';
 	    var recursive = mode.indexOf('r') > -1;
 	    var getAsEntries = mode.indexOf('e') > -1;

--- a/index.js
+++ b/index.js
@@ -152,6 +152,12 @@ module.exports = function(options){
   /* get directory entry */
   function dir(path,options){
     path = normalize(path);
+
+    // Strip trailing slash to prevent fs.root.getDirectory in function dir from returning with a file not found error on Windows
+    if (path.substr(-1) === '/') {
+      path = path.substr(0, path.length - 1);
+    }
+
     options = options || {};
     return new Promise(function(resolve,reject){
       return fs.then(function(fs){


### PR DESCRIPTION
Strip trailing slash to prevent fs.root.getDirectory in function dir from returning with a file not found error on Windows
