### PR TITLE
Added 'existsDir', 'moveDir' and fixed getting quota permissions for persistent file-system on Chrome

### DIFF
--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -154,7 +154,15 @@ var CordovaPromiseFS =
 	        console.warn('Chrome does not support fileSystem "'+type+'". Falling back on "0" (temporary).');
 	        type = 0;
 	      }
-	      window.requestFileSystem(type, options.storageSize, resolve, reject);
+	      // On chrome, request quota to store persistent files
+	      if (!isCordova && type === 1 && navigator.webkitPersistentStorage) {
+	        navigator.webkitPersistentStorage.requestQuota(options.storageSize, function(grantedBytes) {
+	          window.requestFileSystem(type, grantedBytes, resolve, reject);
+	        });
+	      }
+	      else {
+	        window.requestFileSystem(type, options.storageSize, resolve, reject);
+	      }
 	      setTimeout(function(){ reject(new Error('Could not retrieve FileSystem after 5 seconds.')); },5100);
 	    },reject);
 	  });

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -43,7 +43,7 @@ var CordovaPromiseFS =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
 	/**
 	 * Static Private functions
@@ -174,7 +174,7 @@ var CordovaPromiseFS =
 	            resolve(fs.root);
 	          } else {
 	            folders = folders.split('/').filter(function(folder) {
-	              return folder && folder.length > 0 && folder[0] !== '.';
+	              return folder && folder.length > 0 && folder !== '.' && folder !== '..';
 	            });
 	            __createDir(fs.root,folders,resolve,reject);
 	          }
@@ -254,6 +254,24 @@ var CordovaPromiseFS =
 	      file(path).then(
 	        function(fileEntry){
 	          resolve(fileEntry);
+	        },
+	        function(err){
+	          if(err.code === 1) {
+	            resolve(false);
+	          } else {
+	            reject(err);
+	          }
+	        }
+	      );
+	    });
+	  }
+
+	  /* does dir exist? If so, resolve with fileEntry, if not, resolve with false. */
+	  function existsDir(path){
+	    return new Promise(function(resolve,reject){
+	      dir(path).then(
+	        function(dirEntry){
+	          resolve(dirEntry);
 	        },
 	        function(err){
 	          if(err.code === 1) {
@@ -360,6 +378,20 @@ var CordovaPromiseFS =
 	        return file(src).then(function(fileEntry){
 	          return new Promise(function(resolve,reject){
 	            fileEntry.moveTo(dir,filename(dest),resolve,reject);
+	          });
+	        });
+	      });
+	  }
+
+	  /* move a dir */
+	  function moveDir(src,dest) {
+	    src = src.replace(/\/$/, '');
+	    dest = dest.replace(/\/$/, '');
+	    return ensure(dirname(dest))
+	      .then(function(destDir) {
+	        return dir(src).then(function(dirEntry){
+	          return new Promise(function(resolve,reject){
+	            dirEntry.moveTo(destDir,filename(dest),resolve,reject);
 	          });
 	        });
 	      });
@@ -510,12 +542,14 @@ var CordovaPromiseFS =
 	    readJSON: readJSON,
 	    write: write,
 	    move: move,
+	    moveDir: moveDir,
 	    copy: copy,
 	    remove: remove,
 	    removeDir: removeDir,
 	    list: list,
 	    ensure: ensure,
 	    exists: exists,
+	    existsDir: existsDir,
 	    download: download,
 	    upload: upload,
 	    toURL:toURL,

--- a/index.js
+++ b/index.js
@@ -219,6 +219,24 @@ module.exports = function(options){
     });
   }
 
+  /* does dir exist? If so, resolve with fileEntry, if not, resolve with false. */
+  function existsDir(path){
+    return new Promise(function(resolve,reject){
+      dir(path).then(
+        function(dirEntry){
+          resolve(dirEntry);
+        },
+        function(err){
+          if(err.code === 1) {
+            resolve(false);
+          } else {
+            reject(err);
+          }
+        }
+      );
+    });
+  }
+
   function create(path){
     return ensure(dirname(path)).then(function(){
       return file(path,{create:true});
@@ -313,6 +331,20 @@ module.exports = function(options){
         return file(src).then(function(fileEntry){
           return new Promise(function(resolve,reject){
             fileEntry.moveTo(dir,filename(dest),resolve,reject);
+          });
+        });
+      });
+  }
+
+  /* move a dir */
+  function moveDir(src,dest) {
+    src = src.replace(/\/$/, '');
+    dest = dest.replace(/\/$/, '');
+    return ensure(dirname(dest))
+      .then(function(destDir) {
+        return dir(src).then(function(dirEntry){
+          return new Promise(function(resolve,reject){
+            dirEntry.moveTo(destDir,filename(dest),resolve,reject);
           });
         });
       });
@@ -463,12 +495,14 @@ module.exports = function(options){
     readJSON: readJSON,
     write: write,
     move: move,
+    moveDir: moveDir,
     copy: copy,
     remove: remove,
     removeDir: removeDir,
     list: list,
     ensure: ensure,
     exists: exists,
+    existsDir: existsDir,
     download: download,
     upload: upload,
     toURL:toURL,

--- a/index.js
+++ b/index.js
@@ -107,7 +107,15 @@ module.exports = function(options){
         console.warn('Chrome does not support fileSystem "'+type+'". Falling back on "0" (temporary).');
         type = 0;
       }
-      window.requestFileSystem(type, options.storageSize, resolve, reject);
+      // On chrome, request quota to store persistent files
+      if (!isCordova && type === 1 && navigator.webkitPersistentStorage) {
+        navigator.webkitPersistentStorage.requestQuota(options.storageSize, function(grantedBytes) {
+          window.requestFileSystem(type, grantedBytes, resolve, reject);
+        });
+      }
+      else {
+        window.requestFileSystem(type, options.storageSize, resolve, reject);
+      }
       setTimeout(function(){ reject(new Error('Could not retrieve FileSystem after 5 seconds.')); },5100);
     },reject);
   });


### PR DESCRIPTION
Hey Mark,

I've added two new operations on directories which were not yet supported: 'existsDir' and 'moveDir'.
As well as fixed persistent storage on chrome, which was broken.

If you have time, please have a look and pull the changes into the master.
I've already battle tested these changes in my project for about a month now.

cheers, Hein
