### PR TITLE
Encapsulate transfer settings into a plain js object

### DIFF
--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -43,7 +43,7 @@ var CordovaPromiseFS =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ function(module, exports) {
 
 	/**
 	 * Static Private functions
@@ -451,14 +451,14 @@ var CordovaPromiseFS =
 
 	      // fetch filetranfer, method-type (isDownload) and arguments
 	      var args = transferQueue.pop();
-	      var ft = args.shift();
-	      var isDownload = args.shift();
-	      var serverUrl = args.shift();
-	      var localPath = args.shift();
-	      var win = args.shift();
-	      var fail = args.shift();
-	      var trustAllHosts = args.shift();
-	      var transferOptions = args.shift();
+		  var ft = args.fileTransfer,
+		      isDownload = args.isDownload,
+		      serverUrl = args.serverUrl,
+		      localPath = args.localPath,
+		      trustAllHost = args.trustAllHost,
+		      transferOptions = args.transferOptions,
+		      win = args.resolve,
+		      fail = args.attempt;
 
 	      if(ft._aborted) {
 	        inprogress--;
@@ -504,7 +504,17 @@ var CordovaPromiseFS =
 	        if(transferOptions.retry.length === 0) {
 	          reject(err);
 	        } else {
-	          transferQueue.unshift([ft,isDownload,serverUrl,localPath,resolve,attempt,transferOptions.trustAllHosts || false,transferOptions]);
+			  var transferJob = {
+			    fileTransfer:ft,
+			    isDownload:isDownload,
+			    serverUrl:serverUrl,
+			    localPath:localPath,
+			    trustAllHost:transferOptions.trustAllHosts || false,
+			    transferOptions:transferOptions,
+			    win:resolve,
+			    fail:attempt			
+			  };
+	          transferQueue.unshift(transferJob);
 	          var timeout = transferOptions.retry.shift();
 	          if(timeout > 0) {
 	            setTimeout(nextTransfer,timeout);

--- a/index.js
+++ b/index.js
@@ -404,14 +404,14 @@ module.exports = function(options){
 
       // fetch filetranfer, method-type (isDownload) and arguments
       var args = transferQueue.pop();
-      var ft = args.shift();
-      var isDownload = args.shift();
-      var serverUrl = args.shift();
-      var localPath = args.shift();
-      var win = args.shift();
-      var fail = args.shift();
-      var trustAllHosts = args.shift();
-      var transferOptions = args.shift();
+	  var ft = args.fileTransfer,
+	      isDownload = args.isDownload,
+	      serverUrl = args.serverUrl,
+	      localPath = args.localPath,
+	      trustAllHost = args.trustAllHost,
+	      transferOptions = args.transferOptions,
+	      win = args.resolve,
+	      fail = args.attempt;
 
       if(ft._aborted) {
         inprogress--;
@@ -457,7 +457,17 @@ module.exports = function(options){
         if(transferOptions.retry.length === 0) {
           reject(err);
         } else {
-          transferQueue.unshift([ft,isDownload,serverUrl,localPath,resolve,attempt,transferOptions.trustAllHosts || false,transferOptions]);
+		  var transferJob = {
+		    fileTransfer:ft,
+		    isDownload:isDownload,
+		    serverUrl:serverUrl,
+		    localPath:localPath,
+		    trustAllHost:transferOptions.trustAllHosts || false,
+		    transferOptions:transferOptions,
+		    win:resolve,
+		    fail:attempt			
+		  };
+          transferQueue.unshift(transferJob);
           var timeout = transferOptions.retry.shift();
           if(timeout > 0) {
             setTimeout(nextTransfer,timeout);


### PR DESCRIPTION
Hi Mark
I have read all of your code in cordova-promise-fs. You are brilliant and this project is valuable.  
But I wonder if you mind to adjust some of your code to increase the readability of it?  

Instead of filling all transfer settings into an array to pass it to transfer queue, I suggest that we could put these settings into a plain js object to do so.  
I think by doing this we can increase the readability of filetransfer function and popTransferQueue.  Thus I don't have to search back and forth to find out what did the filetransfer function pass to transfer queue.  
It will be intuitive if we take out these transfer settings from an object and start a transfer task in popTransferQueue.   