### PR TITLE
version bump 1.1.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "cordova-promise-fs",
   "main": "dist/CordovaPromiseFS.js",
-  "version": "0.13.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/markmarijnissen/cordova-promise-fs",
   "authors": [
     "Mark Marijnissen <markmarijnissen@gmail.com>"


### PR DESCRIPTION
bower mismatch      Version declared in the json (0.13.0) is different than the resolved one (1.1.1)
bower resolved https://github.com/markmarijnissen/cordova-promise-fs.git#1.1.1