### PR TITLE
Provide ability to write as text instead of as Blob

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Are you entangled in a async callback mess to get even the simplest task done? W
   cordova plugin add cordova-plugin-file-transfer # optional
 ```
 
+### mi-corporation change
+This fork differs from the original repository in the following ways:
+- 2018: write -- don't convert text to Blob
+- 2018: normalize -- avoid appending slash to any path that has a dot in any segment, not just last segment
+- 2018: read -- Handle FileReader errors instead of resolving with null
+- 2024: when accessing the local file system in Android, default to the file:// prefix instead of http://. The reason for this fix is described here:
+https://github.com/apache/cordova-plugin-file-transfer/issues/378
+
+
 **IMPORTANT:** For iOS, use Cordova 3.7.0 or higher (due to a [bug](https://github.com/AppGyver/steroids/issues/534) that affects requestFileSystem).
 
 Or just download and include [CordovaPromiseFS.js](https://raw.githubusercontent.com/markmarijnissen/cordova-promise-fs/master/dist/CordovaPromiseFS.js).

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -446,7 +446,12 @@ module.exports = function(options){
         fileEntry.file(function(file){
           var reader = new FileReader();
           reader.onloadend = function(){
-            resolve(this.result);
+            // Handle errors as well as successes
+            if (reader.error) {
+              reject(reader.error);
+            } else {
+              resolve(reader.result);
+            }
           };
           reader[method](file);
         },reject);

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -475,9 +475,10 @@ module.exports = function(options){
             writer.onwriteend = resolve;
             writer.onerror = reject;
             if(typeof blob === 'string') {
-              blob = createBlob([blob], mimeType || 'text/plain');
+              // blob = createBlob([blob], mimeType || 'text/plain');
             } else if(blob instanceof Blob !== true){
-              blob = createBlob([JSON.stringify(blob,null,4)], mimeType || 'application/json');
+              // blob = createBlob([JSON.stringify(blob,null,4)], mimeType || 'application/json');
+              blob = JSON.stringify(blob,null,4);
             }
             writer.write(blob);
           },reject);

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -101,11 +101,10 @@ function normalize(str){
   str = str || '';
   if(str[0] === '/') str = str.substr(1);
 
-  var tokens = str.split('/'), last = tokens[0];
+  var tokens = str.split('/');
 
   // check tokens for instances of .. and .
   for(var i=1;i < tokens.length;i++) {
-    last = tokens[i];
     if (tokens[i] === '..') {
       // remove the .. and the previous token
       tokens.splice(i-1,2);
@@ -122,7 +121,7 @@ function normalize(str){
   str = tokens.join('/');
   if(str === './') {
     str = '';
-  } else if(last && last.indexOf('.') < 0 && str[str.length - 1] != '/'){
+  } else if(str && str.indexOf('.') < 0 && str[str.length - 1] != '/'){
     str += '/';
   }
   return str;

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -388,7 +388,9 @@ module.exports = function(options){
   /* convert path to URL to be used in JS/CSS/HTML */
   function toURL(path) {
     return file(path).then(function(fileEntry) {
-      return isAndroid ? fileEntry.nativeURL : fileEntry.toURL();
+      // NOTE: we would expect Android to require fileEntry.nativeURL instead of fileEntry.toURL() because it requires the file:// naming scheme rather than http://
+      // however, if we return fileEntry.nativeURL here then the Image Annotation field fails to load images; so leave as is for now since it works
+      return fileEntry.toURL();
     });
   }
 

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -152,7 +152,8 @@ module.exports = function(options){
   /* Cordova deviceready promise */
   var deviceready,
       isCordova = typeof cordova !== 'undefined' && !options.crosswalk,
-      isCrosswalk = options.crosswalk;
+      isCrosswalk = options.crosswalk,
+      isAndroid = isCordova && !/MSAppHost/.test(navigator.userAgent) && /Android/.test(navigator.userAgent);
   if(isCordova){
     deviceready = new Promise(function(resolve,reject){
       document.addEventListener("deviceready", resolve, false);
@@ -238,7 +239,7 @@ module.exports = function(options){
 
   /* debug */
   fs.then(function(fs){
-    CDV_URL_ROOT = fs.root.toURL();
+    CDV_URL_ROOT = isAndroid ? fs.root.nativeURL : fs.root.toURL();
     CDV_INTERNAL_URL_ROOT = isCordova? fs.root.toInternalURL(): CDV_URL_ROOT;
     window.__fs = fs;
   },function(err){

--- a/dist/CordovaPromiseFS.js
+++ b/dist/CordovaPromiseFS.js
@@ -388,7 +388,7 @@ module.exports = function(options){
   /* convert path to URL to be used in JS/CSS/HTML */
   function toURL(path) {
     return file(path).then(function(fileEntry) {
-      return fileEntry.toURL();
+      return isAndroid ? fileEntry.nativeURL : fileEntry.toURL();
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -28,11 +28,10 @@ function normalize(str){
   str = str || '';
   if(str[0] === '/') str = str.substr(1);
 
-  var tokens = str.split('/'), last = tokens[0];
+  var tokens = str.split('/');
 
   // check tokens for instances of .. and .
   for(var i=1;i < tokens.length;i++) {
-    last = tokens[i];
     if (tokens[i] === '..') {
       // remove the .. and the previous token
       tokens.splice(i-1,2);
@@ -49,7 +48,7 @@ function normalize(str){
   str = tokens.join('/');
   if(str === './') {
     str = '';
-  } else if(last && last.indexOf('.') < 0 && str[str.length - 1] != '/'){
+  } else if(str && str.indexOf('.') < 0 && str[str.length - 1] != '/'){
     str += '/';
   }
   return str;

--- a/index.js
+++ b/index.js
@@ -402,9 +402,10 @@ module.exports = function(options){
             writer.onwriteend = resolve;
             writer.onerror = reject;
             if(typeof blob === 'string') {
-              blob = createBlob([blob], mimeType || 'text/plain');
+              // blob = createBlob([blob], mimeType || 'text/plain');
             } else if(blob instanceof Blob !== true){
-              blob = createBlob([JSON.stringify(blob,null,4)], mimeType || 'application/json');
+              // blob = createBlob([JSON.stringify(blob,null,4)], mimeType || 'application/json');
+              blob = JSON.stringify(blob,null,4);
             }
             writer.write(blob);
           },reject);

--- a/index.js
+++ b/index.js
@@ -373,7 +373,12 @@ module.exports = function(options){
         fileEntry.file(function(file){
           var reader = new FileReader();
           reader.onloadend = function(){
-            resolve(this.result);
+            // Handle errors as well as successes
+            if (reader.error) {
+              reject(reader.error);
+            } else {
+              resolve(reader.result);
+            }
           };
           reader[method](file);
         },reject);

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ module.exports = function(options){
           window.requestFileSystem(type, grantedBytes, resolve, reject);
         }, reject);
 
-      // Exotic Cordova Directories (options.fileSystem = string)
+        // Exotic Cordova Directories (options.fileSystem = string)
       } else if(isNaN(type)) {
         window.resolveLocalFileSystemURL(type,function(directory){
             resolve(directory.filesystem);
@@ -315,7 +315,7 @@ module.exports = function(options){
   /* convert path to URL to be used in JS/CSS/HTML */
   function toURL(path) {
     return file(path).then(function(fileEntry) {
-      return fileEntry.toURL();
+      return isAndroid ? fileEntry.nativeURL : fileEntry.toURL();
     });
   }
 
@@ -545,7 +545,7 @@ module.exports = function(options){
       transferOptions = {};
     }
     if(isCordova && localPath.indexOf('://') < 0) localPath = toURLSync(localPath);
-
+    
     transferOptions = transferOptions || {};
     if(!transferOptions.retry || !transferOptions.retry.length) {
       transferOptions.retry = options.retry;

--- a/index.js
+++ b/index.js
@@ -79,7 +79,8 @@ module.exports = function(options){
   /* Cordova deviceready promise */
   var deviceready,
       isCordova = typeof cordova !== 'undefined' && !options.crosswalk,
-      isCrosswalk = options.crosswalk;
+      isCrosswalk = options.crosswalk,
+      isAndroid = isCordova && !/MSAppHost/.test(navigator.userAgent) && /Android/.test(navigator.userAgent);
   if(isCordova){
     deviceready = new Promise(function(resolve,reject){
       document.addEventListener("deviceready", resolve, false);
@@ -165,7 +166,7 @@ module.exports = function(options){
 
   /* debug */
   fs.then(function(fs){
-    CDV_URL_ROOT = fs.root.toURL();
+    CDV_URL_ROOT = isAndroid ? fs.root.nativeURL : fs.root.toURL();
     CDV_INTERNAL_URL_ROOT = isCordova? fs.root.toInternalURL(): CDV_URL_ROOT;
     window.__fs = fs;
   },function(err){

--- a/index.js
+++ b/index.js
@@ -315,7 +315,9 @@ module.exports = function(options){
   /* convert path to URL to be used in JS/CSS/HTML */
   function toURL(path) {
     return file(path).then(function(fileEntry) {
-      return isAndroid ? fileEntry.nativeURL : fileEntry.toURL();
+      // NOTE: we would expect Android to require fileEntry.nativeURL instead of fileEntry.toURL() because it requires the file:// naming scheme rather than http://
+      // however, if we return fileEntry.nativeURL here then the Image Annotation field fails to load images; so leave as is for now since it works
+      return fileEntry.toURL();
     });
   }
 


### PR DESCRIPTION
Currently, `write()` writes everything as a `Blob`. On iOS and Android, [cordova-plugin-file converts `Blob`s to `ArrayBuffer`s](https://github.com/apache/cordova-plugin-file/blob/master/www/FileWriter.js#L99), which the iOS/Android platforms then convert to base64 for transfer to the native layer. (Windows supports marshaling `Blob`s directly from JS to native, so that platform skips the `ArrayBuffer` and base64 conversions.)

I haven't profiled Android in as much detail, but on iOS that conversion to base64 is slow and memory intensive. (Some rough timings below.) An easy workaround for text files is to skip the conversion to `Blob` and write as text. That satisfies our use case of writing large JSON files.

What is the intention behind using `Blob`s? This PR currently comments out the `Blob` conversion completely. I'm assuming that breaks other use cases, so I'm open to amending the PR. For our purposes, we just need a way to opt out of the `Blob` conversion. An optional flag to `write()` would be great. I could also imagine a CordovaPromiseFS constructor option, or maybe the behavior should be platform dependent. I figured I'd start with the simple approach before reaching out about API design.

`write()` timings:
OS: iOS 11.3
Device: iPad Model A 1489 (iPad Mini 2nd Gen)
Cordova iOS platform: 4.4.0
cordova-plugin-file version: 4.3.3
cordova-promise-fs version: 1.2.5

Test - Write a 3.0MB JSON file. Use `console.time` to measure time from calling `write()` until Promise is resolved.
with `Blob` conversion - 3304 ms (median of 18 runs)
writing as text - 575 ms (median of 19 runs)

Let me know if I can provide more info.